### PR TITLE
Arrange art pieces on the divider

### DIFF
--- a/src/components/rooms/GalleryRoom.tsx
+++ b/src/components/rooms/GalleryRoom.tsx
@@ -3,6 +3,8 @@ import { RoomConfig } from "../../types/scene.types";
 import { RigidBody } from "@react-three/rapier";
 import * as THREE from "three";
 import { RoomComments } from "./RoomComments";
+import { ArtFrame } from "../models/ArtFrame";
+import { getArtImageUrl } from "../../configs/artConfig";
 
 interface GalleryRoomProps {
     config: RoomConfig;
@@ -55,6 +57,119 @@ export const GalleryRoom: React.FC<GalleryRoomProps> = ({
                     />
                 </mesh>
             </RigidBody>
+
+            {/* Art pieces along left vertical divider */}
+            {/* Left side of left divider */}
+            <ArtFrame 
+                position={[-width / 4 - 0.5, 2.5, -3]}
+                rotation={[0, Math.PI / 2, 0]}
+                scale={[1.2, 1.2, 1]}
+                imageUrl={getArtImageUrl(22)}
+            />
+            <ArtFrame 
+                position={[-width / 4 - 0.5, 2.5, 3]}
+                rotation={[0, Math.PI / 2, 0]}
+                scale={[1.2, 1.2, 1]}
+                imageUrl={getArtImageUrl(23)}
+            />
+            {/* Right side of left divider */}
+            <ArtFrame 
+                position={[-width / 4 + 0.5, 2.5, -3]}
+                rotation={[0, -Math.PI / 2, 0]}
+                scale={[1.2, 1.2, 1]}
+                imageUrl={getArtImageUrl(0)}
+            />
+            <ArtFrame 
+                position={[-width / 4 + 0.5, 2.5, 3]}
+                rotation={[0, -Math.PI / 2, 0]}
+                scale={[1.2, 1.2, 1]}
+                imageUrl={getArtImageUrl(1)}
+            />
+
+            {/* Art pieces along right vertical divider */}
+            {/* Left side of right divider */}
+            <ArtFrame 
+                position={[width / 4 - 0.5, 2.5, -3]}
+                rotation={[0, Math.PI / 2, 0]}
+                scale={[1.2, 1.2, 1]}
+                imageUrl={getArtImageUrl(2)}
+            />
+            <ArtFrame 
+                position={[width / 4 - 0.5, 2.5, 3]}
+                rotation={[0, Math.PI / 2, 0]}
+                scale={[1.2, 1.2, 1]}
+                imageUrl={getArtImageUrl(3)}
+            />
+            {/* Right side of right divider */}
+            <ArtFrame 
+                position={[width / 4 + 0.5, 2.5, -3]}
+                rotation={[0, -Math.PI / 2, 0]}
+                scale={[1.2, 1.2, 1]}
+                imageUrl={getArtImageUrl(4)}
+            />
+            <ArtFrame 
+                position={[width / 4 + 0.5, 2.5, 3]}
+                rotation={[0, -Math.PI / 2, 0]}
+                scale={[1.2, 1.2, 1]}
+                imageUrl={getArtImageUrl(5)}
+            />
+
+            {/* Art pieces along horizontal connector */}
+            {/* Front side of horizontal divider */}
+            <ArtFrame 
+                position={[-3, 2.5, -0.5]}
+                rotation={[0, 0, 0]}
+                scale={[1.1, 1.1, 1]}
+                imageUrl={getArtImageUrl(6)}
+            />
+            <ArtFrame 
+                position={[3, 2.5, -0.5]}
+                rotation={[0, 0, 0]}
+                scale={[1.1, 1.1, 1]}
+                imageUrl={getArtImageUrl(7)}
+            />
+            {/* Back side of horizontal divider */}
+            <ArtFrame 
+                position={[-3, 2.5, 0.5]}
+                rotation={[0, Math.PI, 0]}
+                scale={[1.1, 1.1, 1]}
+                imageUrl={getArtImageUrl(8)}
+            />
+            <ArtFrame 
+                position={[3, 2.5, 0.5]}
+                rotation={[0, Math.PI, 0]}
+                scale={[1.1, 1.1, 1]}
+                imageUrl={getArtImageUrl(9)}
+            />
+
+            {/* Additional smaller art pieces at different heights */}
+            {/* Left divider - higher pieces */}
+            <ArtFrame 
+                position={[-width / 4 - 0.5, 3.8, 0]}
+                rotation={[0, Math.PI / 2, 0]}
+                scale={[0.8, 0.8, 1]}
+                imageUrl={getArtImageUrl(10)}
+            />
+            <ArtFrame 
+                position={[-width / 4 + 0.5, 3.8, 0]}
+                rotation={[0, -Math.PI / 2, 0]}
+                scale={[0.8, 0.8, 1]}
+                imageUrl={getArtImageUrl(11)}
+            />
+
+            {/* Right divider - higher pieces */}
+            <ArtFrame 
+                position={[width / 4 - 0.5, 3.8, 0]}
+                rotation={[0, Math.PI / 2, 0]}
+                scale={[0.8, 0.8, 1]}
+                imageUrl={getArtImageUrl(12)}
+            />
+            <ArtFrame 
+                position={[width / 4 + 0.5, 3.8, 0]}
+                rotation={[0, -Math.PI / 2, 0]}
+                scale={[0.8, 0.8, 1]}
+                imageUrl={getArtImageUrl(13)}
+            />
         </>
     );
 };


### PR DESCRIPTION
Art pieces were added to the `GalleryRoom` component in `src/components/rooms/GalleryRoom.tsx`. The `ArtFrame` component and `getArtImageUrl` utility were imported to facilitate this.

A total of 16 `ArtFrame` instances were strategically placed along the three dividers within the `GalleryRoom`:
*   **Left Vertical Divider (x = -5):** Four main art pieces (two on each side at height 2.5m) and two smaller pieces higher up (at height 3.8m).
*   **Right Vertical Divider (x =  5):** Four main art pieces (two on each side at height 2.5m) and two smaller pieces higher up (at height 3.8m).
*   **Horizontal Connector (z = 0):** Four art pieces (two on each side at height 2.5m).

Each `ArtFrame` was configured with specific `position` values to ensure proper placement on both sides of the dividers, `rotation` to face outwards, and varied `scale` (1.2x, 1.1x, 0.8x) for visual diversity. Different `imageUrl` values were used via `getArtImageUrl` to display a variety of artworks.

This modification transforms the structural dividers into active exhibition spaces, significantly increasing the gallery's capacity and creating more immersive viewing experiences by allowing art to be viewed from multiple angles.