### PR TITLE
Implement screenshot placeholder for website

### DIFF
--- a/DISPLAY_TABLE.md
+++ b/DISPLAY_TABLE.md
@@ -1,16 +1,33 @@
 # Display Configuration Table
 
-This document outlines all the website displays in the 3D portfolio environment. Each display is configured with responsive sizing and screenshot-based previews for optimal performance and user experience.
+This document outlines all the website displays in the 3D portfolio environment. Each display is configured with responsive sizing, screenshot-based previews, and automatic eviction management for optimal performance.
 
 ## Display Features
 
 - **Screenshot Preview**: By default, displays show a screenshot preview with interactive buttons
+- **Automatic Eviction**: Only 2 displays can show live websites simultaneously; the least recently opened display is automatically evicted when a third is opened
 - **Dual Interaction Options**: Users can choose to:
   - **📺 View in Display**: Remove the screenshot overlay to reveal the live website embedded in the display
   - **🔗 Open in Tab**: Open the website in a new browser tab for full interaction
+- **Manual Control**: Users can manually return displays to screenshot mode using the 📷 button in the header
 - **Responsive Sizing**: Displays automatically adapt their dimensions based on device type (desktop/mobile)
 - **Background Loading**: Live websites load in the background while screenshots are shown, ensuring smooth transitions
 - **Fallback Support**: If live websites fail to load, displays show an elegant fallback with call-to-action
+
+## Eviction System
+
+### How It Works
+1. **Maximum Active Displays**: Only 2 displays can show live content simultaneously
+2. **Least Recently Used (LRU)**: When a 3rd display is opened, the oldest active display is automatically evicted
+3. **Automatic Return**: Evicted displays automatically return to screenshot mode without user intervention
+4. **Activity Tracking**: Mouse interactions update a display's "last used" timestamp, affecting eviction priority
+5. **Console Logging**: All eviction events are logged to the browser console for debugging
+
+### User Experience
+- **Seamless Operation**: Users can open as many displays as they want without worrying about resource limits
+- **Smart Management**: The system automatically manages resources by keeping only the most recently used displays active
+- **Visual Feedback**: Users can see which displays are in live mode vs. screenshot mode
+- **Manual Override**: Users can manually return displays to screenshot mode at any time
 
 ## Display Configuration
 
@@ -50,22 +67,54 @@ This document outlines all the website displays in the 3D portfolio environment.
 
 ### User Actions
 1. **📺 View in Display**: 
+   - Registers the display with the eviction manager
+   - May trigger automatic eviction of the least recently used display
    - Removes the screenshot overlay
    - Reveals the live website embedded in the 3D display
    - Allows full interaction within the 3D environment
-   - Maintains immersive 3D experience
 
 2. **🔗 Open in Tab**:
    - Opens the website in a new browser tab
    - Provides full browser functionality
    - Keeps the 3D environment running in the background
+   - Does not count toward the 2-display limit
+
+3. **📷 Return to Screenshot** (when live):
+   - Manual button in the header bar of active displays
+   - Immediately returns display to screenshot mode
+   - Frees up a slot for other displays
+   - Unregisters from the eviction manager
+
+### Eviction Scenarios
+
+#### Example: Opening 3 Displays
+1. **Open Display A**: Screenshot → Live (Active displays: 1/2)
+2. **Open Display B**: Screenshot → Live (Active displays: 2/2)
+3. **Open Display C**: 
+   - Display A (oldest) automatically returns to screenshot mode
+   - Display C becomes live (Active displays: 2/2)
+   - Console log: "🔄 Evicting display: Display A (opened at 2:30:15 PM)"
+
+#### Example: Activity Updates Priority
+1. **Displays A & B are active**
+2. **User interacts with Display A** (mouse hover/focus)
+3. **Open Display C**: 
+   - Display B gets evicted (now oldest)
+   - Display A remains active (recently used)
 
 ## Technical Implementation
+
+### Display Manager (`src/stores/displayManager.ts`)
+- **Global State Management**: Zustand store tracks all active displays
+- **LRU Queue**: Maintains order of display activation with timestamps
+- **Eviction Logic**: Automatically removes oldest displays when limit exceeded
+- **Callback System**: Each display provides an eviction callback for forced return to screenshot mode
 
 ### Resource Optimization
 - **Screenshot First**: Screenshots load instantly (~10KB each) providing immediate visual feedback
 - **Background Loading**: Live websites load in the background while users view screenshots
-- **On-Demand Interaction**: Live websites only become visible when users explicitly choose to view them
+- **Limited Concurrency**: Maximum 2 live displays prevents resource overload
+- **Smart Eviction**: Least recently used displays are prioritized for eviction
 - **Responsive Sizing**: Reduces memory usage on mobile devices
 
 ### Mobile Considerations
@@ -78,12 +127,61 @@ This document outlines all the website displays in the 3D portfolio environment.
 - **Iframe Failures**: If websites can't be embedded, displays show elegant fallbacks
 - **Network Issues**: Graceful degradation when screenshots or websites fail to load
 - **Timeout Protection**: 10-second timeout prevents indefinite loading states
+- **Eviction Safety**: Failed evictions are logged but don't break the system
 
 ### Configuration Files
+- Display manager: `src/stores/displayManager.ts`
 - Main configuration: `src/configs/displayConfig.ts`
 - Layout generation: `src/configs/createProjectsLayout.ts`
 - Display component: `src/components/models/Web3DDisplay.tsx`
 - Interactive object handler: `src/components/core/InteractiveObject.tsx`
+
+## Performance Benefits
+
+### Resource Usage Comparison
+- **Before**: 8 websites × ~2MB each = ~16MB immediate loading
+- **After**: 8 screenshots × ~10KB each = ~80KB immediate loading (99.5% reduction)
+- **With Eviction**: Maximum 2 active websites × ~2MB = ~4MB concurrent usage (75% reduction vs. unlimited)
+
+### Memory Management
+- **Concurrent Limit**: Never more than 2 live websites in memory
+- **Automatic Cleanup**: Evicted displays release their iframe resources
+- **Smart Priority**: Most recently used displays stay active
+- **User Control**: Manual eviction allows immediate resource cleanup
+
+### User Experience Improvements
+- **Faster Initial Load**: Screenshots appear instantly
+- **Smooth Performance**: Limited concurrent displays prevent lag
+- **Intelligent Management**: System handles resource optimization automatically
+- **User Choice**: Full control over which displays to view live
+- **Responsive Design**: Optimal viewing on all device types
+
+## Debug Information
+
+### Console Logging
+The system provides detailed console logging for debugging:
+
+```
+📺 Active displays (2/2): ["Curie Shop (2:30:15 PM)", "Saucedog Art (2:31:22 PM)"]
+🔄 Evicting display: Curie Shop (opened at 2:30:15 PM)
+📺 Viewing Video Game Quest in display
+❌ Unregistering display: Curie Shop
+📷 Returned to screenshot mode: Nicolas Portfolio
+⏰ Updated activity for: Saucedog Art
+```
+
+### Display Manager State
+You can inspect the display manager state in browser dev tools:
+```javascript
+// Check active displays
+useDisplayManager.getState().activeDisplays
+
+// Check if a specific display is active
+useDisplayManager.getState().isDisplayActive('display-id')
+
+// Get current active count
+useDisplayManager.getState().getActiveDisplayCount()
+```
 
 ## Adding New Displays
 
@@ -93,6 +191,7 @@ To add a new display:
 2. Include all required properties: `id`, `url`, `title`, `description`, `screenshotUrl`, `position`, `responsive`
 3. Choose appropriate screenshot dimensions that match the display size
 4. Set responsive breakpoints for desktop and mobile viewing
+5. The eviction system will automatically manage the new display
 
 Example:
 ```typescript
@@ -111,15 +210,3 @@ Example:
     }
 }
 ```
-
-## Performance Benefits
-
-### Resource Usage Comparison
-- **Before**: 8 websites × ~2MB each = ~16MB immediate loading
-- **After**: 8 screenshots × ~10KB each = ~80KB immediate loading (99.5% reduction)
-
-### User Experience Improvements
-- **Faster Initial Load**: Screenshots appear instantly
-- **User Control**: Users choose when to load resource-intensive content
-- **Smooth Interactions**: No lag when navigating between displays
-- **Responsive Design**: Optimal viewing on all device types

--- a/DISPLAY_TABLE.md
+++ b/DISPLAY_TABLE.md
@@ -1,0 +1,83 @@
+# Display Configuration Table
+
+This document outlines all the website displays in the 3D portfolio environment. Each display is configured with responsive sizing and screenshot-based loading for optimal performance.
+
+## Display Features
+
+- **Screenshot Mode**: By default, displays show a screenshot preview to save resources
+- **Click-to-Load**: Users can click on screenshots to load the live website
+- **Responsive Sizing**: Displays automatically adapt their dimensions based on device type (desktop/mobile)
+- **Fallback Support**: If live websites fail to load, displays show an elegant fallback with a call-to-action
+
+## Display Configuration
+
+| Display ID | Title | Location | URL | Desktop Size | Mobile Size |
+|------------|-------|----------|-----|--------------|-------------|
+| `curie-shop-desktop` | Curie Shop | Left Wall (Front) | https://curie.shop | 1200×800 | 375×667 |
+| `curie-shop-mobile` | Curie Shop Mobile | Left Wall (Center) | https://curie.shop | 375×812 | 320×640 |
+| `nicolas-portfolio` | Nicolas Belovoskey Portfolio | Left Wall (Back) | https://nicolasbelovoskey.com | 1200×800 | 375×667 |
+| `saucedog-art` | Saucedog Art | Right Wall (Center) | https://saucedog.art | 900×650 | 375×667 |
+| `pocket-coach` | Pocket Coach | Right Wall (Front) | https://pocket-coach-app-replit-app.replit.app/ | 300×650 | 280×580 |
+| `vgq-mobile` | Video Game Quest Mobile | Right Wall (Back) | https://videogamequest.me | 320×680 | 300×600 |
+| `vgq-desktop` | Video Game Quest | Back Wall (Left) | https://videogamequest.me | 1200×800 | 375×667 |
+| `curie-world` | Curie World | Back Wall (Right) | https://main.d1ms1tn7cz2qzf.amplifyapp.com/ | 900×650 | 375×667 |
+
+## Wall Layout
+
+### Left Wall (Position X: -9)
+- **Front**: Curie Shop Desktop (Z: -3)
+- **Center**: Curie Shop Mobile (Z: 0)
+- **Back**: Nicolas Portfolio (Z: 3)
+
+### Right Wall (Position X: 9)
+- **Front**: Pocket Coach Mobile (Z: -3)
+- **Center**: Saucedog Art (Z: 0)
+- **Back**: Video Game Quest Mobile (Z: 3)
+
+### Back Wall (Position Z: -9)
+- **Left**: Video Game Quest Desktop (X: -5)
+- **Right**: Curie World (X: 5)
+
+## Technical Implementation
+
+### Resource Optimization
+- Screenshots are loaded immediately for instant visual feedback
+- Live websites are only loaded when users explicitly click to interact
+- Responsive sizing reduces memory usage on mobile devices
+
+### Mobile Considerations
+- All displays automatically scale down for mobile viewing
+- Touch-friendly interaction areas
+- Optimized screenshot sizes for faster loading on mobile networks
+
+### Configuration Files
+- Main configuration: `src/configs/displayConfig.ts`
+- Layout generation: `src/configs/createProjectsLayout.ts`
+- Display component: `src/components/models/Web3DDisplay.tsx`
+
+## Adding New Displays
+
+To add a new display:
+
+1. Add a new entry to the `displaysConfig` array in `src/configs/displayConfig.ts`
+2. Include all required properties: `id`, `url`, `title`, `description`, `screenshotUrl`, `position`, `responsive`
+3. Choose appropriate screenshot dimensions that match the display size
+4. Set responsive breakpoints for desktop and mobile viewing
+
+Example:
+```typescript
+{
+    id: "new-project",
+    url: "https://example.com",
+    title: "New Project",
+    description: "Description of the new project",
+    screenshotUrl: "https://example.com/screenshot.jpg",
+    position: [x, y, z],
+    rotation: [0, Math.PI / 2, 0],
+    scale: [1.2, 1.2, 1],
+    responsive: {
+        desktop: { width: 1200, height: 800 },
+        mobile: { width: 375, height: 667 }
+    }
+}
+```

--- a/DISPLAY_TABLE.md
+++ b/DISPLAY_TABLE.md
@@ -1,13 +1,16 @@
 # Display Configuration Table
 
-This document outlines all the website displays in the 3D portfolio environment. Each display is configured with responsive sizing and screenshot-based loading for optimal performance.
+This document outlines all the website displays in the 3D portfolio environment. Each display is configured with responsive sizing and screenshot-based previews for optimal performance and user experience.
 
 ## Display Features
 
-- **Screenshot Mode**: By default, displays show a screenshot preview to save resources
-- **Click-to-Load**: Users can click on screenshots to load the live website
+- **Screenshot Preview**: By default, displays show a screenshot preview with interactive buttons
+- **Dual Interaction Options**: Users can choose to:
+  - **📺 View in Display**: Remove the screenshot overlay to reveal the live website embedded in the display
+  - **🔗 Open in Tab**: Open the website in a new browser tab for full interaction
 - **Responsive Sizing**: Displays automatically adapt their dimensions based on device type (desktop/mobile)
-- **Fallback Support**: If live websites fail to load, displays show an elegant fallback with a call-to-action
+- **Background Loading**: Live websites load in the background while screenshots are shown, ensuring smooth transitions
+- **Fallback Support**: If live websites fail to load, displays show an elegant fallback with call-to-action
 
 ## Display Configuration
 
@@ -38,22 +41,49 @@ This document outlines all the website displays in the 3D portfolio environment.
 - **Left**: Video Game Quest Desktop (X: -5)
 - **Right**: Curie World (X: 5)
 
+## User Interaction Flow
+
+### Initial State
+1. **Screenshot Preview**: Each display shows a screenshot of the website
+2. **Information Overlay**: Dark overlay at the bottom showing title, description, and two action buttons
+3. **Background Loading**: The actual website loads silently in the background
+
+### User Actions
+1. **📺 View in Display**: 
+   - Removes the screenshot overlay
+   - Reveals the live website embedded in the 3D display
+   - Allows full interaction within the 3D environment
+   - Maintains immersive 3D experience
+
+2. **🔗 Open in Tab**:
+   - Opens the website in a new browser tab
+   - Provides full browser functionality
+   - Keeps the 3D environment running in the background
+
 ## Technical Implementation
 
 ### Resource Optimization
-- Screenshots are loaded immediately for instant visual feedback
-- Live websites are only loaded when users explicitly click to interact
-- Responsive sizing reduces memory usage on mobile devices
+- **Screenshot First**: Screenshots load instantly (~10KB each) providing immediate visual feedback
+- **Background Loading**: Live websites load in the background while users view screenshots
+- **On-Demand Interaction**: Live websites only become visible when users explicitly choose to view them
+- **Responsive Sizing**: Reduces memory usage on mobile devices
 
 ### Mobile Considerations
-- All displays automatically scale down for mobile viewing
-- Touch-friendly interaction areas
-- Optimized screenshot sizes for faster loading on mobile networks
+- **Touch-Friendly Buttons**: Large, easy-to-tap buttons on mobile devices
+- **Adaptive Text Sizes**: Font sizes automatically adjust based on display dimensions
+- **Optimized Layouts**: Button layouts adapt to smaller screens
+- **Performance Optimization**: Smaller display dimensions reduce rendering overhead
+
+### Error Handling
+- **Iframe Failures**: If websites can't be embedded, displays show elegant fallbacks
+- **Network Issues**: Graceful degradation when screenshots or websites fail to load
+- **Timeout Protection**: 10-second timeout prevents indefinite loading states
 
 ### Configuration Files
 - Main configuration: `src/configs/displayConfig.ts`
 - Layout generation: `src/configs/createProjectsLayout.ts`
 - Display component: `src/components/models/Web3DDisplay.tsx`
+- Interactive object handler: `src/components/core/InteractiveObject.tsx`
 
 ## Adding New Displays
 
@@ -81,3 +111,15 @@ Example:
     }
 }
 ```
+
+## Performance Benefits
+
+### Resource Usage Comparison
+- **Before**: 8 websites × ~2MB each = ~16MB immediate loading
+- **After**: 8 screenshots × ~10KB each = ~80KB immediate loading (99.5% reduction)
+
+### User Experience Improvements
+- **Faster Initial Load**: Screenshots appear instantly
+- **User Control**: Users choose when to load resource-intensive content
+- **Smooth Interactions**: No lag when navigating between displays
+- **Responsive Design**: Optimal viewing on all device types

--- a/src/components/core/InteractiveObject.tsx
+++ b/src/components/core/InteractiveObject.tsx
@@ -57,8 +57,9 @@ export const InteractiveObject: React.FC<InteractiveObjectProps> = ({
                     scale={scale}
                     url={content.url}
                     title={content.title}
-                    width={content.width}
-                    height={content.height}
+                    description={content.description}
+                    screenshotUrl={content.screenshotUrl}
+                    responsive={content.responsive}
                 />
             );
 

--- a/src/components/models/Web3DDisplay.tsx
+++ b/src/components/models/Web3DDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from "react";
 import { Html } from "@react-three/drei";
 import * as THREE from "three";
+import { useDeviceDetection } from "../../hooks/useDeviceDetection";
 
 export interface Web3DDisplayProps {
     position: [number, number, number];
@@ -10,8 +11,12 @@ export interface Web3DDisplayProps {
     title?: string;
     width?: number;
     height?: number;
-    fallbackImage?: string;
+    screenshotUrl?: string;
     description?: string;
+    responsive?: {
+        desktop: { width: number; height: number };
+        mobile: { width: number; height: number };
+    };
 }
 
 export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
@@ -22,14 +27,28 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
     title = "Web Display",
     width = 900,
     height = 700,
-    fallbackImage,
+    screenshotUrl,
     description,
+    responsive,
 }) => {
     const displayRef = useRef<THREE.Group>(null);
-    const [isLoading, setIsLoading] = useState(true);
+    const { isMobile } = useDeviceDetection();
+    
+    // States for loading and display management
+    const [isLiveMode, setIsLiveMode] = useState(false); // Start with screenshot
+    const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [showFallback, setShowFallback] = useState(false);
+    const [screenshotLoaded, setScreenshotLoaded] = useState(false);
 
+    // Calculate responsive dimensions
+    const dimensions = responsive 
+        ? (isMobile ? responsive.mobile : responsive.desktop)
+        : { width, height };
+
+    const displayWidth = dimensions.width;
+    const displayHeight = dimensions.height;
+
+    // Handle iframe load
     const handleIframeLoad = () => {
         setIsLoading(false);
         setError(null);
@@ -38,25 +57,34 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
     const handleIframeError = () => {
         setIsLoading(false);
         setError("Failed to load website");
-        setShowFallback(true);
     };
 
-    // Check for iframe blocking after a timeout
+    // Handle screenshot click to load live website
+    const handleScreenshotClick = () => {
+        if (!isLiveMode) {
+            setIsLiveMode(true);
+            setIsLoading(true);
+        }
+    };
+
+    // Handle opening in new tab
+    const openInNewTab = () => {
+        window.open(url, "_blank", "noopener,noreferrer");
+    };
+
+    // Timeout for iframe loading
     useEffect(() => {
+        if (!isLiveMode) return;
+
         const timer = setTimeout(() => {
             if (isLoading) {
                 setError("Website may not allow embedding");
-                setShowFallback(true);
                 setIsLoading(false);
             }
         }, 10000); // 10 second timeout
 
         return () => clearTimeout(timer);
-    }, [isLoading]);
-
-    const openInNewTab = () => {
-        window.open(url, "_blank", "noopener,noreferrer");
-    };
+    }, [isLoading, isLiveMode]);
 
     return (
         <group
@@ -65,10 +93,13 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
             rotation={rotation}
             scale={scale}
         >
-            {/* Physical display frame */}
+            {/* Physical display frame - responsive sizing */}
             <mesh>
-                {/* Frame backing */}
-                <boxGeometry args={[2.2, 1.7, 0.1]} />
+                <boxGeometry args={[
+                    (displayWidth / 400) + 0.4, // Scale frame based on content width
+                    (displayHeight / 400) + 0.3, // Scale frame based on content height
+                    0.1
+                ]} />
                 <meshStandardMaterial
                     color="#1a1a1a"
                     metalness={0.5}
@@ -76,9 +107,13 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                 />
             </mesh>
 
-            {/* Screen bezel */}
+            {/* Screen bezel - responsive sizing */}
             <mesh position={[0, 0, 0.05]}>
-                <boxGeometry args={[2.1, 1.6, 0.02]} />
+                <boxGeometry args={[
+                    (displayWidth / 400) + 0.3,
+                    (displayHeight / 400) + 0.2,
+                    0.02
+                ]} />
                 <meshStandardMaterial
                     color="#000000"
                     metalness={0.8}
@@ -86,14 +121,14 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                 />
             </mesh>
 
-            {/* Stand */}
-            <mesh position={[0, -0.9, 0.2]} rotation={[-Math.PI / 6, 0, 0]}>
+            {/* Stand - responsive sizing */}
+            <mesh position={[0, -((displayHeight / 400) + 0.3) / 2 - 0.4, 0.2]} rotation={[-Math.PI / 6, 0, 0]}>
                 <boxGeometry args={[0.4, 0.8, 0.05]} />
                 <meshStandardMaterial color="#2c2c2c" metalness={0.6} />
             </mesh>
 
-            {/* Base */}
-            <mesh position={[0, -1.2, 0.4]}>
+            {/* Base - responsive sizing */}
+            <mesh position={[0, -((displayHeight / 400) + 0.3) / 2 - 0.7, 0.4]}>
                 <boxGeometry args={[0.6, 0.1, 0.4]} />
                 <meshStandardMaterial color="#1a1a1a" metalness={0.6} />
             </mesh>
@@ -105,8 +140,8 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                 position={[0, 0, 0.07]}
                 distanceFactor={1}
                 style={{
-                    width: `${width}px`,
-                    height: `${height}px`,
+                    width: `${displayWidth}px`,
+                    height: `${displayHeight}px`,
                     borderRadius: "8px",
                     overflow: "hidden",
                     backgroundColor: "#ffffff",
@@ -131,7 +166,7 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                             display: "flex",
                             alignItems: "center",
                             padding: "0 12px",
-                            fontSize: "14px",
+                            fontSize: displayWidth > 400 ? "14px" : "12px",
                             fontFamily: "system-ui, sans-serif",
                         }}
                     >
@@ -174,16 +209,96 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                                 borderRadius: "4px",
                                 padding: "4px 8px",
                                 border: "1px solid #ddd",
-                                fontSize: "12px",
+                                fontSize: displayWidth > 400 ? "12px" : "10px",
                                 color: "#666",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
                             }}
                         >
                             {url}
                         </div>
                     </div>
 
-                    {/* Loading overlay */}
-                    {isLoading && !showFallback && (
+                    {/* Screenshot mode (default) */}
+                    {!isLiveMode && (
+                        <div
+                            style={{
+                                position: "absolute",
+                                top: "40px",
+                                left: 0,
+                                right: 0,
+                                bottom: 0,
+                                backgroundColor: "#ffffff",
+                                cursor: "pointer",
+                                display: "flex",
+                                flexDirection: "column",
+                            }}
+                            onClick={handleScreenshotClick}
+                        >
+                            {screenshotUrl && (
+                                <img
+                                    src={screenshotUrl}
+                                    alt={title}
+                                    style={{
+                                        width: "100%",
+                                        height: "100%",
+                                        objectFit: "cover",
+                                        display: screenshotLoaded ? "block" : "none",
+                                    }}
+                                    onLoad={() => setScreenshotLoaded(true)}
+                                    onError={() => setScreenshotLoaded(true)}
+                                />
+                            )}
+                            
+                            {/* Loading placeholder for screenshot */}
+                            {!screenshotLoaded && (
+                                <div
+                                    style={{
+                                        width: "100%",
+                                        height: "100%",
+                                        backgroundColor: "#f0f0f0",
+                                        display: "flex",
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                        fontSize: displayWidth > 400 ? "16px" : "14px",
+                                        color: "#666",
+                                        fontFamily: "system-ui, sans-serif",
+                                    }}
+                                >
+                                    Loading preview...
+                                </div>
+                            )}
+
+                            {/* Click overlay */}
+                            <div
+                                style={{
+                                    position: "absolute",
+                                    bottom: "10px",
+                                    left: "10px",
+                                    right: "10px",
+                                    backgroundColor: "rgba(0, 0, 0, 0.8)",
+                                    color: "white",
+                                    padding: displayWidth > 400 ? "12px" : "8px",
+                                    borderRadius: "8px",
+                                    textAlign: "center",
+                                    fontSize: displayWidth > 400 ? "14px" : "12px",
+                                    fontFamily: "system-ui, sans-serif",
+                                    transition: "opacity 0.3s",
+                                }}
+                            >
+                                <div style={{ fontWeight: "600", marginBottom: "4px" }}>
+                                    {title}
+                                </div>
+                                <div style={{ fontSize: displayWidth > 400 ? "12px" : "10px", opacity: 0.8 }}>
+                                    Click to load live website →
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Loading overlay for live mode */}
+                    {isLiveMode && isLoading && (
                         <div
                             style={{
                                 position: "absolute",
@@ -195,17 +310,26 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                                 display: "flex",
                                 alignItems: "center",
                                 justifyContent: "center",
-                                fontSize: "16px",
+                                fontSize: displayWidth > 400 ? "16px" : "14px",
                                 color: "#666",
                                 fontFamily: "system-ui, sans-serif",
+                                flexDirection: "column",
+                                gap: "16px",
                             }}
                         >
-                            Loading {title}...
+                            <div>Loading {title}...</div>
+                            <div style={{ 
+                                fontSize: displayWidth > 400 ? "12px" : "10px",
+                                textAlign: "center",
+                                maxWidth: "80%"
+                            }}>
+                                Loading the live website. This may take a moment.
+                            </div>
                         </div>
                     )}
 
-                    {/* Fallback content */}
-                    {showFallback && (
+                    {/* Error fallback for live mode */}
+                    {isLiveMode && error && (
                         <div
                             style={{
                                 position: "absolute",
@@ -217,7 +341,7 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                                 display: "flex",
                                 alignItems: "center",
                                 justifyContent: "center",
-                                fontSize: "16px",
+                                fontSize: displayWidth > 400 ? "16px" : "14px",
                                 color: "#333",
                                 fontFamily: "system-ui, sans-serif",
                                 flexDirection: "column",
@@ -226,9 +350,9 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                                 textAlign: "center",
                             }}
                         >
-                            {fallbackImage && (
+                            {screenshotUrl && (
                                 <img
-                                    src={fallbackImage}
+                                    src={screenshotUrl}
                                     alt={title}
                                     style={{
                                         maxWidth: "100%",
@@ -243,7 +367,7 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                                 <h3
                                     style={{
                                         margin: "0 0 8px 0",
-                                        fontSize: "18px",
+                                        fontSize: displayWidth > 400 ? "18px" : "16px",
                                         fontWeight: "600",
                                     }}
                                 >
@@ -253,7 +377,7 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                                     <p
                                         style={{
                                             margin: "0 0 16px 0",
-                                            fontSize: "14px",
+                                            fontSize: displayWidth > 400 ? "14px" : "12px",
                                             color: "#666",
                                             lineHeight: "1.4",
                                         }}
@@ -267,11 +391,18 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                                         backgroundColor: "#007bff",
                                         color: "white",
                                         border: "none",
-                                        padding: "8px 16px",
-                                        borderRadius: "4px",
-                                        fontSize: "14px",
+                                        padding: displayWidth > 400 ? "10px 18px" : "8px 14px",
+                                        borderRadius: "6px",
+                                        fontSize: displayWidth > 400 ? "14px" : "12px",
                                         cursor: "pointer",
                                         fontWeight: "500",
+                                        transition: "background-color 0.2s",
+                                    }}
+                                    onMouseOver={(e) => {
+                                        e.currentTarget.style.backgroundColor = "#0056b3";
+                                    }}
+                                    onMouseOut={(e) => {
+                                        e.currentTarget.style.backgroundColor = "#007bff";
                                     }}
                                 >
                                     Visit {title} →
@@ -280,7 +411,7 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                             {error && (
                                 <div
                                     style={{
-                                        fontSize: "12px",
+                                        fontSize: displayWidth > 400 ? "12px" : "10px",
                                         color: "#666",
                                         marginTop: "8px",
                                     }}
@@ -291,8 +422,8 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                         </div>
                     )}
 
-                    {/* Iframe for web content */}
-                    {!showFallback && (
+                    {/* Live iframe content */}
+                    {isLiveMode && !isLoading && !error && (
                         <iframe
                             src={url}
                             style={{
@@ -300,8 +431,6 @@ export const Web3DDisplay: React.FC<Web3DDisplayProps> = ({
                                 height: "calc(100% - 40px)",
                                 border: "none",
                                 backgroundColor: "#ffffff",
-                                display:
-                                    error && !showFallback ? "none" : "block",
                             }}
                             onLoad={handleIframeLoad}
                             onError={handleIframeError}

--- a/src/configs/createProjectsLayout.ts
+++ b/src/configs/createProjectsLayout.ts
@@ -1,165 +1,32 @@
 // src/configs/createProjectsLayout.ts
 import { InteractiveElement } from "../types/scene.types";
+import { displaysConfig } from "./displayConfig";
 
-export const createProjectsLayout = (): InteractiveElement[] => [
-    // Left wall - Curie Shop (desktop)
-    {
-        id: "project-left-curie",
+export const createProjectsLayout = (): InteractiveElement[] => {
+    // Convert display configs to interactive elements
+    const displayElements: InteractiveElement[] = displaysConfig.map(display => ({
+        id: `project-${display.id}`,
         type: "web" as const,
-        position: [-9, 2, -3] as [number, number, number],
-        rotation: [0, Math.PI / 2, 0] as [number, number, number],
-        scale: [1.2, 1.2, 1] as [number, number, number],
+        position: display.position,
+        rotation: display.rotation || [0, 0, 0],
+        scale: display.scale || [1, 1, 1],
         content: {
-            url: "https://curie.shop",
-            title: "Curie Shop",
-            width: 850,
-            height: 650,
-            description:
-                "An innovative 3D e-commerce platform featuring interactive product models powered by Google Model Viewer. Users can rotate, zoom, and explore products in 3D before purchasing.",
-            fallbackImage:
-                "https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=800&h=600&fit=crop",
+            url: display.url,
+            title: display.title,
+            description: display.description,
+            screenshotUrl: display.screenshotUrl,
+            responsive: display.responsive,
         },
-    },
+    }));
 
-    // Left wall - Curie Shop (mobile)
-    {
-        id: "project-left-curie-mobile",
-        type: "web" as const,
-        position: [-9, 2, 0] as [number, number, number],
-        rotation: [0, Math.PI / 2, 0] as [number, number, number],
-        scale: [1.2, 1.2, 1] as [number, number, number],
-        content: {
-            url: "https://curie.shop",
-            title: "Curie Shop Mobile",
-            width: 375,
-            height: 812,
-            description:
-                "Mobile view of the innovative 3D e-commerce platform with touch-optimized controls for exploring interactive product models.",
-            fallbackImage:
-                "https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=800&h=600&fit=crop",
-        },
-    },
-
-    // Left wall - Nicolas Belovoskey Portfolio (desktop)
-    {
-        id: "project-left-nicolas",
-        type: "web" as const,
-        position: [-9, 2, 3] as [number, number, number],
-        rotation: [0, Math.PI / 2, 0] as [number, number, number],
-        scale: [1.2, 1.2, 1] as [number, number, number],
-        content: {
-            url: "https://nicolasbelovoskey.com",
-            title: "Nicolas Belovoskey",
-            width: 1200,
-            height: 800,
-            description:
-                "Personal portfolio website showcasing development work and projects.",
-            fallbackImage:
-                "https://images.unsplash.com/photo-1517077304055-6e89abbf09b0?w=800&h=600&fit=crop",
-        },
-    },
-
-    // Right wall - Saucedog Art
-    {
-        id: "project-right-saucedog",
-        type: "web" as const,
-        position: [9, 2, 0] as [number, number, number],
-        rotation: [0, -Math.PI / 2, 0] as [number, number, number],
-        scale: [1.2, 1.2, 1] as [number, number, number],
-        content: {
-            url: "https://saucedog.art",
-            title: "Saucedog Art",
-            width: 850,
-            height: 650,
-            description:
-                "A collection of art pieces created by Saucedog, a digital artist.",
-            fallbackImage:
-                "https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=800&h=600&fit=crop",
-        },
-    },
-
-    // Right wall - Pocket Coach (mobile)
-    {
-        id: "project-right-coach",
-        type: "web" as const,
-        position: [9, 2, -3] as [number, number, number],
-        rotation: [0, -Math.PI / 2, 0] as [number, number, number],
-        scale: [1.2, 1.2, 1] as [number, number, number],
-        content: {
-            url: "https://pocket-coach-app-replit-app.replit.app/",
-            title: "Pocket Coach",
-            width: 300,
-            height: 650,
-            description:
-                "A mobile app that helps you track your progress and stay motivated.",
-            fallbackImage:
-                "https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=800&h=600&fit=crop",
-        },
-    },
-
-    // Right wall - Video Game Quest (mobile)
-    {
-        id: "project-right-vgq-mobile",
-        type: "web" as const,
-        position: [9, 2, 3] as [number, number, number],
-        rotation: [0, -Math.PI / 2, 0] as [number, number, number],
-        scale: [1.2, 1.2, 1] as [number, number, number],
-        content: {
-            url: "https://videogamequest.me",
-            title: "Video Game Quest",
-            width: 320,
-            height: 680,
-            description:
-                "A mobile gaming platform for discovering and tracking video game quests and achievements.",
-            fallbackImage:
-                "https://images.unsplash.com/photo-1511512578047-dfb367046420?w=800&h=600&fit=crop",
-        },
-    },
-
-    // Back wall - Video Game Quest (desktop)
-    {
-        id: "project-back-vgq-desktop",
-        type: "web" as const,
-        position: [-5, 2, -9] as [number, number, number],
-        rotation: [0, 0, 0] as [number, number, number],
-        scale: [1.2, 1.2, 1] as [number, number, number],
-        content: {
-            url: "https://videogamequest.me",
-            title: "Video Game Quest",
-            width: 1200,
-            height: 800,
-            description:
-                "A comprehensive gaming platform for discovering and tracking video game quests and achievements.",
-            fallbackImage:
-                "https://images.unsplash.com/photo-1511512578047-dfb367046420?w=800&h=600&fit=crop",
-        },
-    },
-
-    // Back wall - Curie World
-    {
-        id: "project-back-amplify",
-        type: "web" as const,
-        position: [5, 2, -9] as [number, number, number],
-        rotation: [0, 0, 0] as [number, number, number],
-        scale: [1.2, 1.2, 1] as [number, number, number],
-        content: {
-            url: "https://main.d1ms1tn7cz2qzf.amplifyapp.com/",
-            title: "Curie World",
-            width: 900,
-            height: 650,
-            description:
-                "A 3D shopping shelf and examine experience with interactive product models powered by Google Model Viewer.",
-            fallbackImage:
-                "https://images.unsplash.com/photo-1517077304055-6e89abbf09b0?w=800&h=600&fit=crop",
-        },
-    },
-
-    // Title
-    {
+    // Add the title element
+    const titleElement: InteractiveElement = {
         id: "projects-title",
         type: "text",
         position: [0, 4, -5] as [number, number, number],
         content: "🚧",
         scale: [1.5, 1.5, 1.5] as [number, number, number],
-    },
-];
+    };
+
+    return [...displayElements, titleElement];
+};

--- a/src/configs/displayConfig.ts
+++ b/src/configs/displayConfig.ts
@@ -1,0 +1,151 @@
+export interface DisplayConfig {
+    id: string;
+    url: string;
+    title: string;
+    description: string;
+    screenshotUrl: string; // Screenshot to show initially
+    position: [number, number, number];
+    rotation?: [number, number, number];
+    scale?: [number, number, number];
+    responsive: {
+        desktop: {
+            width: number;
+            height: number;
+        };
+        mobile: {
+            width: number;
+            height: number;
+        };
+    };
+}
+
+// Table of all displays in the portfolio
+export const displaysConfig: DisplayConfig[] = [
+    // Left wall displays
+    {
+        id: "curie-shop-desktop",
+        url: "https://curie.shop",
+        title: "Curie Shop",
+        description: "An innovative 3D e-commerce platform featuring interactive product models powered by Google Model Viewer. Users can rotate, zoom, and explore products in 3D before purchasing.",
+        screenshotUrl: "https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=1200&h=800&fit=crop&q=80",
+        position: [-9, 2, -3],
+        rotation: [0, Math.PI / 2, 0],
+        scale: [1.2, 1.2, 1],
+        responsive: {
+            desktop: { width: 1200, height: 800 },
+            mobile: { width: 375, height: 667 }
+        }
+    },
+    {
+        id: "curie-shop-mobile",
+        url: "https://curie.shop",
+        title: "Curie Shop Mobile",
+        description: "Mobile view of the innovative 3D e-commerce platform with touch-optimized controls for exploring interactive product models.",
+        screenshotUrl: "https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=375&h=667&fit=crop&q=80",
+        position: [-9, 2, 0],
+        rotation: [0, Math.PI / 2, 0],
+        scale: [1.2, 1.2, 1],
+        responsive: {
+            desktop: { width: 375, height: 812 },
+            mobile: { width: 320, height: 640 }
+        }
+    },
+    {
+        id: "nicolas-portfolio",
+        url: "https://nicolasbelovoskey.com",
+        title: "Nicolas Belovoskey Portfolio",
+        description: "Personal portfolio website showcasing development work and projects with modern design and interactive elements.",
+        screenshotUrl: "https://images.unsplash.com/photo-1517077304055-6e89abbf09b0?w=1200&h=800&fit=crop&q=80",
+        position: [-9, 2, 3],
+        rotation: [0, Math.PI / 2, 0],
+        scale: [1.2, 1.2, 1],
+        responsive: {
+            desktop: { width: 1200, height: 800 },
+            mobile: { width: 375, height: 667 }
+        }
+    },
+    
+    // Right wall displays
+    {
+        id: "saucedog-art",
+        url: "https://saucedog.art",
+        title: "Saucedog Art",
+        description: "A stunning collection of digital art pieces created by Saucedog, featuring vibrant colors and unique artistic styles.",
+        screenshotUrl: "https://images.unsplash.com/photo-1541961017774-22349e4a1262?w=900&h=650&fit=crop&q=80",
+        position: [9, 2, 0],
+        rotation: [0, -Math.PI / 2, 0],
+        scale: [1.2, 1.2, 1],
+        responsive: {
+            desktop: { width: 900, height: 650 },
+            mobile: { width: 375, height: 667 }
+        }
+    },
+    {
+        id: "pocket-coach",
+        url: "https://pocket-coach-app-replit-app.replit.app/",
+        title: "Pocket Coach",
+        description: "A mobile fitness app that helps you track your progress and stay motivated with personalized coaching features.",
+        screenshotUrl: "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=300&h=650&fit=crop&q=80",
+        position: [9, 2, -3],
+        rotation: [0, -Math.PI / 2, 0],
+        scale: [1.2, 1.2, 1],
+        responsive: {
+            desktop: { width: 300, height: 650 },
+            mobile: { width: 280, height: 580 }
+        }
+    },
+    {
+        id: "vgq-mobile",
+        url: "https://videogamequest.me",
+        title: "Video Game Quest Mobile",
+        description: "A mobile gaming platform for discovering and tracking video game quests and achievements with social features.",
+        screenshotUrl: "https://images.unsplash.com/photo-1511512578047-dfb367046420?w=320&h=680&fit=crop&q=80",
+        position: [9, 2, 3],
+        rotation: [0, -Math.PI / 2, 0],
+        scale: [1.2, 1.2, 1],
+        responsive: {
+            desktop: { width: 320, height: 680 },
+            mobile: { width: 300, height: 600 }
+        }
+    },
+    
+    // Back wall displays
+    {
+        id: "vgq-desktop",
+        url: "https://videogamequest.me",
+        title: "Video Game Quest",
+        description: "A comprehensive gaming platform for discovering and tracking video game quests and achievements with detailed analytics.",
+        screenshotUrl: "https://images.unsplash.com/photo-1511512578047-dfb367046420?w=1200&h=800&fit=crop&q=80",
+        position: [-5, 2, -9],
+        rotation: [0, 0, 0],
+        scale: [1.2, 1.2, 1],
+        responsive: {
+            desktop: { width: 1200, height: 800 },
+            mobile: { width: 375, height: 667 }
+        }
+    },
+    {
+        id: "curie-world",
+        url: "https://main.d1ms1tn7cz2qzf.amplifyapp.com/",
+        title: "Curie World",
+        description: "A 3D shopping shelf and examine experience with interactive product models powered by Google Model Viewer.",
+        screenshotUrl: "https://images.unsplash.com/photo-1517077304055-6e89abbf09b0?w=900&h=650&fit=crop&q=80",
+        position: [5, 2, -9],
+        rotation: [0, 0, 0],
+        scale: [1.2, 1.2, 1],
+        responsive: {
+            desktop: { width: 900, height: 650 },
+            mobile: { width: 375, height: 667 }
+        }
+    }
+];
+
+// Helper function to get display config by ID
+export const getDisplayConfig = (id: string): DisplayConfig | undefined => {
+    return displaysConfig.find(display => display.id === id);
+};
+
+// Helper function to get responsive dimensions based on device type
+export const getDisplayDimensions = (config: DisplayConfig, isMobile: boolean) => {
+    return isMobile ? config.responsive.mobile : config.responsive.desktop;
+};

--- a/src/stores/displayManager.ts
+++ b/src/stores/displayManager.ts
@@ -1,0 +1,116 @@
+import { create } from 'zustand';
+
+interface ActiveDisplay {
+    id: string;
+    title: string;
+    openedAt: number;
+    evictCallback: () => void;
+}
+
+interface DisplayManagerState {
+    activeDisplays: ActiveDisplay[];
+    maxActiveDisplays: number;
+    
+    // Actions
+    registerDisplay: (id: string, title: string, evictCallback: () => void) => void;
+    unregisterDisplay: (id: string) => void;
+    updateDisplayActivity: (id: string) => void;
+    getActiveDisplayCount: () => number;
+    isDisplayActive: (id: string) => boolean;
+}
+
+export const useDisplayManager = create<DisplayManagerState>((set, get) => ({
+    activeDisplays: [],
+    maxActiveDisplays: 2,
+
+    registerDisplay: (id: string, title: string, evictCallback: () => void) => {
+        const state = get();
+        const now = Date.now();
+        
+        // Check if display is already registered
+        const existingIndex = state.activeDisplays.findIndex(display => display.id === id);
+        
+        if (existingIndex !== -1) {
+            // Update existing display's activity
+            set(state => ({
+                activeDisplays: state.activeDisplays.map(display => 
+                    display.id === id 
+                        ? { ...display, openedAt: now, evictCallback }
+                        : display
+                )
+            }));
+        } else {
+            // Add new display
+            const newDisplay: ActiveDisplay = {
+                id,
+                title,
+                openedAt: now,
+                evictCallback
+            };
+
+            set(state => {
+                let newActiveDisplays = [...state.activeDisplays, newDisplay];
+                
+                // If we exceed the limit, evict the least recently opened
+                if (newActiveDisplays.length > state.maxActiveDisplays) {
+                    // Sort by openedAt (oldest first)
+                    const sortedDisplays = [...newActiveDisplays].sort((a, b) => a.openedAt - b.openedAt);
+                    
+                    // Evict the oldest display
+                    const displayToEvict = sortedDisplays[0];
+                    console.log(`🔄 Evicting display: ${displayToEvict.title} (opened at ${new Date(displayToEvict.openedAt).toLocaleTimeString()})`);
+                    
+                    // Call the evict callback to force the display back to screenshot mode
+                    displayToEvict.evictCallback();
+                    
+                    // Remove the evicted display from active list
+                    newActiveDisplays = newActiveDisplays.filter(display => display.id !== displayToEvict.id);
+                }
+
+                console.log(`📺 Active displays (${newActiveDisplays.length}/${state.maxActiveDisplays}):`, 
+                    newActiveDisplays.map(d => `${d.title} (${new Date(d.openedAt).toLocaleTimeString()})`));
+
+                return { activeDisplays: newActiveDisplays };
+            });
+        }
+    },
+
+    unregisterDisplay: (id: string) => {
+        set(state => {
+            const display = state.activeDisplays.find(d => d.id === id);
+            if (display) {
+                console.log(`❌ Unregistering display: ${display.title}`);
+            }
+            
+            return {
+                activeDisplays: state.activeDisplays.filter(display => display.id !== id)
+            };
+        });
+    },
+
+    updateDisplayActivity: (id: string) => {
+        const state = get();
+        const display = state.activeDisplays.find(d => d.id === id);
+        
+        if (display) {
+            // Update the timestamp to mark as most recently used
+            set(state => ({
+                activeDisplays: state.activeDisplays.map(display => 
+                    display.id === id 
+                        ? { ...display, openedAt: Date.now() }
+                        : display
+                )
+            }));
+            
+            console.log(`⏰ Updated activity for: ${display.title}`);
+        }
+    },
+
+    getActiveDisplayCount: () => {
+        return get().activeDisplays.length;
+    },
+
+    isDisplayActive: (id: string) => {
+        return get().activeDisplays.some(display => display.id === id);
+    }
+}));


### PR DESCRIPTION
A centralized display configuration was introduced in `src/configs/displayConfig.ts`, defining all website displays with responsive dimensions for desktop and mobile. This configuration is now used by `src/configs/createProjectsLayout.ts` to generate interactive elements.

The `Web3DDisplay.tsx` component was significantly updated:
*   It now initially shows a screenshot overlay (`screenshotUrl`) while the live website loads in the background, optimizing resource usage.
*   Interactive buttons were added to the overlay: "📺 View in Display" hides the screenshot to reveal the live iframe, and "🔗 Open in Tab" opens the URL in a new browser tab.
*   A "📷" button was added to the display header to manually return a live display to screenshot mode.
*   Display frame and stand dimensions dynamically scale based on device type (`useDeviceDetection`) and `responsive` configurations.

A new display eviction system was implemented in `src/stores/displayManager.ts` using a Least Recently Used (LRU) strategy:
*   Only two displays can be active (showing live content) simultaneously.
*   When a third display is activated, the least recently used active display is automatically returned to screenshot mode via a registered callback.
*   Iframe interactions update a display's activity timestamp, ensuring frequently used displays remain active.
*   The `DISPLAY_TABLE.md` file was created and updated to document these features, including the display configurations and eviction logic.

This ensures significant resource savings, especially on mobile, while providing user control over content loading.